### PR TITLE
Add ck_player_opacity convar

### DIFF
--- a/csgo/addons/sourcemod/scripting/ckSurf.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf.sp
@@ -418,6 +418,7 @@ ConVar g_hPlayerSkinChange = null; 								// Allow changing player models?
 ConVar g_hCountry = null; 										// Display countries for players?
 ConVar g_hAutoRespawn = null; 									// Respawn players automatically?
 ConVar g_hCvarNoBlock = null; 									// Allow player blocking?
+ConVar g_hCvarPlayerOpacity = null; 						// Player opacity (translucency)
 ConVar g_hPointSystem = null; 									// Use the point system?
 ConVar g_hCleanWeapons = null; 									// Clean weapons from ground?
 int g_ownerOffset; 												// Used to clear weapons from ground
@@ -1353,6 +1354,12 @@ public void OnSettingChanged(Handle convar, const char[] oldValue, const char[] 
 					SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 5, 4, true);
 		}
 	}
+	else if (convar == g_hCvarPlayerOpacity)
+	{
+		for (int client = 1; client <= MAXPLAYERS; client++)
+			if (IsValidEntity(client) && GetEntityRenderMode(client) != RENDER_NONE)
+				SetPlayerVisible(client);
+	}
 	else if (convar == g_hCleanWeapons)
 	{
 		if (GetConVarBool(g_hCleanWeapons))
@@ -1755,6 +1762,8 @@ public void OnPluginStart()
 	HookConVarChange(g_hAutoRespawn, OnSettingChanged);
 	g_hCvarNoBlock = CreateConVar("ck_noblock", "1", "on/off - Player no blocking", FCVAR_NOTIFY, true, 0.0, true, 1.0);
 	HookConVarChange(g_hCvarNoBlock, OnSettingChanged);
+	g_hCvarPlayerOpacity = CreateConVar("ck_player_opacity", "255", "0-255 - Player opacity (0 invisible, 255 fully visible)", FCVAR_NOTIFY, true, 0.0, true, 255.0);
+	HookConVarChange(g_hCvarPlayerOpacity, OnSettingChanged);
 	g_hAdminClantag = CreateConVar("ck_admin_clantag", "1", "on/off - Admin clan tag (necessary flag: b - z)", FCVAR_NOTIFY, true, 0.0, true, 1.0);
 	HookConVarChange(g_hAdminClantag, OnSettingChanged);
 	g_hReplayBot = CreateConVar("ck_replay_bot", "1", "on/off - Bots mimic the local map record", FCVAR_NOTIFY, true, 0.0, true, 1.0);

--- a/csgo/addons/sourcemod/scripting/ckSurf/buttonpress.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/buttonpress.sp
@@ -51,7 +51,7 @@ public void CL_OnStartTimerPress(int client)
 		g_fStartPauseTime[client] = 0.0;
 		g_bPause[client] = false;
 		SetEntityMoveType(client, MOVETYPE_WALK);
-		SetEntityRenderMode(client, RENDER_NORMAL);
+		SetPlayerVisible(client);
 		g_fStartTime[client] = GetGameTime();
 		g_fCurrentRunTime[client] = 0.0;
 		g_bPositionRestored[client] = false;

--- a/csgo/addons/sourcemod/scripting/ckSurf/commands.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/commands.sp
@@ -1956,7 +1956,7 @@ public void PauseMethod(int client)
 			if (g_fPauseTime[client] > 0.0)
 				g_fStartPauseTime[client] = g_fStartPauseTime[client] - g_fPauseTime[client];
 		}
-		SetEntityRenderMode(client, RENDER_NONE);
+		SetPlayerInvisible(client);
 		SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 2, 4, true);
 	}
 	else
@@ -1969,7 +1969,7 @@ public void PauseMethod(int client)
 		g_bPause[client] = false;
 		if (!g_bRoundEnd)
 			SetEntityMoveType(client, MOVETYPE_WALK);
-		SetEntityRenderMode(client, RENDER_NORMAL);
+		SetPlayerVisible(client);
 		if (GetConVarBool(g_hCvarNoBlock))
 			SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 2, 4, true);
 		else
@@ -2222,7 +2222,7 @@ public void Action_NoClip(int client)
 					g_fCurrentRunTime[client] = -1.0;
 				}
 				SetEntityMoveType(client, MOVETYPE_NOCLIP);
-				SetEntityRenderMode(client, RENDER_NONE);
+				SetPlayerInvisible(client);
 				SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 2, 4, true);
 				g_bNoClip[client] = true;
 			}
@@ -2243,7 +2243,7 @@ public void Action_UnNoClip(int client)
 			if (mt == MOVETYPE_NOCLIP)
 			{
 				SetEntityMoveType(client, MOVETYPE_WALK);
-				SetEntityRenderMode(client, RENDER_NORMAL);
+				SetPlayerVisible(client);
 				if (GetConVarBool(g_hCvarNoBlock))
 					SetEntData(client, FindSendPropInfo("CBaseEntity", "m_CollisionGroup"), 2, 4, true);
 				else

--- a/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
@@ -54,7 +54,7 @@ public Action Event_OnPlayerSpawn(Handle event, const char[] name, bool dontBroa
 		g_bPause[client] = false;
 		g_bFirstTimerStart[client] = true;
 		SetEntityMoveType(client, MOVETYPE_WALK);
-		SetEntityRenderMode(client, RENDER_NORMAL);
+		SetPlayerVisible(client);
 		
 		//strip weapons
 		if ((GetClientTeam(client) > 1) && IsValidClient(client))

--- a/csgo/addons/sourcemod/scripting/ckSurf/misc.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/misc.sp
@@ -3136,3 +3136,36 @@ void resetZone(int zoneIndex)
 	g_mapZones[zoneIndex][Team] = 0;
 	g_mapZones[zoneIndex][zoneGroup] = 0;
 }
+
+void SetPlayerVisible(int client)
+{
+	int iAlpha = GetConVarInt(g_hCvarPlayerOpacity);
+	SetEntityOpacity(client, iAlpha);
+
+	// Render weapons opaque too.
+	int iWeapon = -1, iIndex;
+	while((iWeapon = Client_GetNextWeapon(client, iIndex)) != -1)
+		SetEntityOpacity(iWeapon, iAlpha);
+}
+
+void SetPlayerInvisible(int client)
+{
+	SetEntityRenderMode(client, RENDER_NONE);
+}
+
+void SetEntityOpacity(int ent, int iAlpha)
+{
+	if (iAlpha == 255)
+	{
+		SetEntityRenderMode(ent, RENDER_NORMAL);
+	}
+	// else if (iAlpha == 0)
+	// {
+	// 	SetEntityRenderMode(ent, RENDER_NONE);
+	// }
+	else
+	{
+		SetEntityRenderMode(ent, RENDER_TRANSCOLOR);
+		Entity_SetRenderColor(ent, -1, -1, -1, iAlpha);
+	}
+}

--- a/csgo/cfg/sourcemod/ckSurf/main.cfg
+++ b/csgo/cfg/sourcemod/ckSurf/main.cfg
@@ -18,5 +18,6 @@ sv_full_alltalk 1
 sv_max_queries_sec 6
 sv_pure 0
 weapon_reticle_knife_show 1
+sv_disable_immunity_alpha 1
 sv_infinite_ammo 2
 log off


### PR DESCRIPTION
Add cvar to make players opaque.

* I don't know why exactly but held weapons are unaffected, yet to fix (do you know if I need to alter attached props?)
* `sv_disable_immunity_alpha` must be set to 1. I do not check nor alter this cvar but I added it to the default config (cfg/sourcemod/ckSurf/main.cfg)