### PR TITLE
Remove MySQL's "ONLY_FULL_GROUP_BY" from sql_mode (fixes #43)

### DIFF
--- a/csgo/addons/sourcemod/scripting/ckSurf/sql.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/sql.sp
@@ -163,6 +163,7 @@ public void db_setupDatabase()
 
 	if (strcmp(szIdent, "mysql", false) == 0)
 	{
+		SQL_FastQuery(g_hDb, "SET sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));");
 		g_DbType = MYSQL;
 	}
 	else


### PR DESCRIPTION
Newer versions of MySQL have this sql_mode as default which will cause a lot of CK's queries to fail. This will remove this sql_mode if set (and only for the given connection). This is a "workaround" since the (poor) queries should be fixed instead.