### PR TITLE
Chat handler improvements (fixes #16)

### DIFF
--- a/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
@@ -329,20 +329,20 @@ public Action Say_Hook(int client, const char[] command, int argc)
   // build: rank
   if (bUseChatRank)
   {
-    Format(sTextFinal, sizeof(sTextFinal), "%s {green}%s{default}", szChatRank);
+    Format(sTextFinal, sizeof(sTextFinal), "%s {green}%s{default}", sTextFinal, szChatRank);
   }
 
   // build: spec/death inserts
   if (GetClientTeam(client) == TEAM_SPECTATOR)
-    Format(sTextFinal, sizeof(sTextFinal), "%s {default}%s", "*SPEC*");
+    Format(sTextFinal, sizeof(sTextFinal), "%s {default}%s", sTextFinal, "*SPEC*");
   else if (!IsPlayerAlive(client))
-    Format(sTextFinal, sizeof(sTextFinal), "%s {default}%s", "*DEAD*");
+    Format(sTextFinal, sizeof(sTextFinal), "%s {default}%s", sTextFinal, "*DEAD*");
 
   // build: player name & message
   if (GetClientTeam(client) == TEAM_SPECTATOR)
-    Format(sTextFinal, sizeof(sTextFinal), "%s {grey}%s{default}: %s", szName, sText);
+    Format(sTextFinal, sizeof(sTextFinal), "%s {grey}%s{default}: %s", sTextFinal, szName, sText);
   else
-    Format(sTextFinal, sizeof(sTextFinal), "%s {default}%s{default}: %s", szName, sText);
+    Format(sTextFinal, sizeof(sTextFinal), "%s {default}%s{default}: %s", sTextFinal, szName, sText);
 
   // print message to chat
   CPrintToChatAll("%s", sTextFinal);

--- a/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
@@ -280,8 +280,10 @@ public Action Say_Hook(int client, const char[] command, int argc)
   }
 
   // abort if client invoked hidden chat command (hidden_chat_commands.txt)
+  char commandlookup[128][128];
+  ExplodeString(sText, " ", commandlookup, 1, 128);
   for (int i = 0; i < sizeof(g_BlockedChatText); i++)
-    if (StrEqual(g_BlockedChatText[i], sText, true))
+    if (StrEqual(g_BlockedChatText[i], commandlookup[0], false))
       return Plugin_Handled;
 
   // check spam (warns/kicks spamming players), should be after blocked commands (for !r, etc.)

--- a/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
@@ -329,7 +329,7 @@ public Action Say_Hook(int client, const char[] command, int argc)
   // build: rank
   if (bUseChatRank)
   {
-    Format(sTextFinal, sizeof(sTextFinal), "%s {green}%s{default}", sTextFinal, szChatRank);
+    Format(sTextFinal, sizeof(sTextFinal), "%s {default}%s{default}", sTextFinal, szChatRank);
   }
 
   // build: spec/death inserts

--- a/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
@@ -272,7 +272,7 @@ public Action Say_Hook(int client, const char[] command, int argc)
       return Plugin_Handled;
 
   // lowercase commands if first character is uppercase
-  if (IsChatTrigger() && IsCharUpper(sText[1]))
+  if ((sText[0] == '/' || sText[0] == '!') && IsCharUpper(sText[1]))
   {
     for (int i = 0; i <= strlen(sText); ++i)
     {
@@ -328,9 +328,7 @@ public Action Say_Hook(int client, const char[] command, int argc)
 
   // build: rank
   if (bUseChatRank)
-  {
     Format(sTextFinal, sizeof(sTextFinal), "%s {default}%s{default}", sTextFinal, szChatRank);
-  }
 
   // build: spec/death inserts
   if (GetClientTeam(client) == TEAM_SPECTATOR)

--- a/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/hooks.sp
@@ -266,11 +266,6 @@ public Action Say_Hook(int client, const char[] command, int argc)
   if (BaseComm_IsClientGagged(client))
     return Plugin_Handled;
 
-  // abort if client invoked hidden chat command (hidden_chat_commands.txt)
-  for (int i = 0; i < sizeof(g_BlockedChatText); i++)
-    if (StrEqual(g_BlockedChatText[i], sText, true))
-      return Plugin_Handled;
-
   // lowercase commands if first character is uppercase
   if ((sText[0] == '/' || sText[0] == '!') && IsCharUpper(sText[1]))
   {
@@ -283,6 +278,11 @@ public Action Say_Hook(int client, const char[] command, int argc)
     FakeClientCommand(client, "say %s", sText);
     return Plugin_Handled;
   }
+
+  // abort if client invoked hidden chat command (hidden_chat_commands.txt)
+  for (int i = 0; i < sizeof(g_BlockedChatText); i++)
+    if (StrEqual(g_BlockedChatText[i], sText, true))
+      return Plugin_Handled;
 
   // check spam (warns/kicks spamming players), should be after blocked commands (for !r, etc.)
   if (checkSpam(client))

--- a/csgo/addons/sourcemod/scripting/ckSurf/misc.sp
+++ b/csgo/addons/sourcemod/scripting/ckSurf/misc.sp
@@ -2166,52 +2166,6 @@ public int GetSkillgroupFromPoints(int points)
 	return 0;
 }
 
-stock Action PrintSpecMessageAll(int client)
-{
-	char szName[64];
-	GetClientName(client, szName, sizeof(szName));
-	normalizeChatString(szName, 64);
-
-	char szTextToAll[1024];
-	GetCmdArgString(szTextToAll, sizeof(szTextToAll));
-	StripQuotes(szTextToAll);
-	if (StrEqual(szTextToAll, "") || StrEqual(szTextToAll, " ") || StrEqual(szTextToAll, "  "))
-		return Plugin_Handled;
-
-	normalizeChatString(szTextToAll, 1024);
-	char szChatRank[64];
-	Format(szChatRank, 64, "%s", g_pr_chat_coloredrank[client]);
-
-	if (GetConVarBool(g_hPointSystem) && GetConVarBool(g_hColoredNames))
-		Format(szName,sizeof(szName),"%s%s",g_pr_rankColor[client],szName);
-
-	if (GetConVarBool(g_hCountry) && (GetConVarBool(g_hPointSystem) || ((StrEqual(g_pr_rankname[client], "ADMIN", false)) && GetConVarBool(g_hAdminClantag))))
-		CPrintToChatAll("{green}%s{default} %s *SPEC* {grey}%s{default}: %s", g_szCountryCode[client], szChatRank, szName, szTextToAll);
-	else
-		if (GetConVarBool(g_hPointSystem) || ((StrEqual(g_pr_rankname[client], "ADMIN", false)) && GetConVarBool(g_hAdminClantag)))
-			CPrintToChatAll("%s *SPEC* {grey}%s{default}: %s", szChatRank, szName, szTextToAll);
-		else
-			if (GetConVarBool(g_hCountry))
-				CPrintToChatAll("[{green}%s{default}] *SPEC* {grey}%s{default}: %s", g_szCountryCode[client], szName, szTextToAll);
-			else
-				CPrintToChatAll("*SPEC* {grey}%s{default}: %s", szName, szTextToAll);
-
-	for (int i = 1; i <= MaxClients; i++)
-		if (IsValidClient(i))
-		{
-			if (GetConVarBool(g_hCountry) && (GetConVarBool(g_hPointSystem) || ((StrEqual(g_pr_rankname[client], "ADMIN", false)) && GetConVarBool(g_hAdminClantag))))
-				PrintToConsole(i, "%s [%s] *SPEC* %s: %s", g_szCountryCode[client], g_pr_rankname[client], szName, szTextToAll);
-			else
-				if (GetConVarBool(g_hPointSystem) || ((StrEqual(g_pr_rankname[client], "ADMIN", false)) && GetConVarBool(g_hAdminClantag)))
-					PrintToConsole(i, "[%s] *SPEC* %s: %s", g_szCountryCode[client], szName, szTextToAll);
-				else
-					if (GetConVarBool(g_hPointSystem))
-						PrintToConsole(i, "[%s] *SPEC* %s: %s", g_pr_rankname[client], szName, szTextToAll);
-					else
-						PrintToConsole(i, "*SPEC* %s: %s", szName, szTextToAll);
-		}
-	return Plugin_Handled;
-}
 //http://pastebin.com/YdUWS93H
 public bool CheatFlag(const char[] voice_inputfromfile, bool isCommand, bool remove)
 {


### PR DESCRIPTION
I mostly just refactored this function, removed a lot of duplication and brainfucking if/else constructs and added a bunch of comments.

* The special handling of !b/!bonus and !s/!stage is removed which was already handled by hidden_chat_commands and thereby fixes #16 or things like `Hey, use !b for bonus` or `!boobs` ;)
* All chat messages will now appear in player consoles (opposed to only chat messages from spectators)
* Hidden chat commands that accept arguments will now be hidden as well (thx @the133448)

I tested it with a few different configurations and so far it looks good, maybe someone could try a build before we merge? But hurry I want my hacktoberfest shirt :D